### PR TITLE
Explicitly require 'ansi'

### DIFF
--- a/lib/minitest/reporters/turn_again_reporter.rb
+++ b/lib/minitest/reporters/turn_again_reporter.rb
@@ -22,6 +22,7 @@ module Minitest
     # @see https://github.com/kern/minitest-reporters/blob/master/lib/minitest/reporters/spec_reporter.rb SpecReporter
     # @see https://github.com/TwP/turn turn
     class TurnAgainReporter < BaseReporter
+      require 'ansi'
       include ANSI::Code
       include RelativePosition
 


### PR DESCRIPTION
Lets turn-again-reporter work in a case where both it and minitest-reporters are not auto-required by Bundler. Fixes #1.
